### PR TITLE
Add namespace to build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,6 +29,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'org.jitsi.jitsi_meet_flutter_sdk'
     compileSdkVersion 33
 
     compileOptions {


### PR DESCRIPTION
Adds the namespace to the build script since it's required since AGP 8.0.0